### PR TITLE
Darken bg color

### DIFF
--- a/tokens/design-tokens.json
+++ b/tokens/design-tokens.json
@@ -24,7 +24,7 @@
       "neutral": {
         "50": {
           "type": "color",
-          "value": "#f9fafbff",
+          "value": "#f3f5f7ff",
           "blendMode": "normal"
         },
         "75": {


### PR DESCRIPTION
Following an internal discussion around Callouts, we decided that the default background color is too light to contrast on white background (or the other way around). This PR changes the `neutral.50` token a bit, hopefully enough to fix the contrast issue.

Change-type: patch